### PR TITLE
Fix usage of `site_url` (Fixes #4)

### DIFF
--- a/includes/modules/local-seo/views/titles-options.php
+++ b/includes/modules/local-seo/views/titles-options.php
@@ -51,7 +51,7 @@ $cmb->add_field(
 		'type'    => 'text_url',
 		'name'    => esc_html__( 'URL', 'rank-math' ),
 		'desc'    => esc_html__( 'URL of the item.', 'rank-math' ),
-		'default' => site_url(),
+		'default' => home_url(),
 	]
 );
 

--- a/includes/modules/redirections/class-redirection.php
+++ b/includes/modules/redirections/class-redirection.php
@@ -248,9 +248,9 @@ class Redirection {
 	public function add_destination( $url ) {
 		$processed = trim( wp_strip_all_tags( $url, true ) );
 
-		// If beginning looks like a domain but without protocol then let's add site_url().
+		// If beginning looks like a domain but without protocol then let's add home_url().
 		if ( ! empty( $processed ) && Url::is_relative( $processed ) ) {
-			$processed = site_url( $processed );
+			$processed = home_url( $processed );
 		}
 
 		$this->data['url_to'] = $processed;
@@ -337,7 +337,7 @@ class Redirection {
 			return false;
 		}
 
-		return urldecode( untrailingslashit( Redirection::strip_subdirectory( $url ) ) );
+		return urldecode( untrailingslashit( $url ) );
 	}
 
 	/**
@@ -372,7 +372,7 @@ class Redirection {
 		global $wpdb;
 
 		// Check for post.
-		$post_id = url_to_postid( site_url( $slug ) );
+		$post_id = url_to_postid( home_url( $slug ) );
 		if ( $post_id ) {
 			$this->cache[] = [
 				'from_url'    => $slug,
@@ -431,21 +431,8 @@ class Redirection {
 			return $this->domain;
 		}
 
-		$this->domain = Url::get_domain( site_url() );
+		$this->domain = Url::get_domain( home_url() );
 
 		return $this->domain;
-	}
-
-	/**
-	 * Strip home directory when WP is installed in subdirectory
-	 *
-	 * @param string $url URL to strip from.
-	 *
-	 * @return string
-	 */
-	public static function strip_subdirectory( $url ) {
-		$home_dir = ltrim( site_url( '', 'relative' ), '/' );
-
-		return $home_dir ? str_replace( trailingslashit( $home_dir ), '', $url ) : $url;
 	}
 }

--- a/includes/modules/redirections/class-redirector.php
+++ b/includes/modules/redirections/class-redirector.php
@@ -88,9 +88,9 @@ class Redirector {
 	 * Set the required values.
 	 */
 	private function start() {
-		$this->uri = str_replace( site_url( '/' ), '', Param::server( 'REQUEST_URI' ) );
+		$this->uri = str_replace( home_url( '/' ), '', Param::server( 'REQUEST_URI' ) );
 		$this->uri = urldecode( $this->uri );
-		$this->uri = trim( Redirection::strip_subdirectory( $this->uri ), '/' );
+		$this->uri = trim( $this->uri ), '/' );
 
 		// Complete request uri.
 		$this->full_uri = $this->uri;

--- a/includes/modules/redirections/class-redirector.php
+++ b/includes/modules/redirections/class-redirector.php
@@ -90,7 +90,7 @@ class Redirector {
 	private function start() {
 		$this->uri = str_replace( home_url( '/' ), '', Param::server( 'REQUEST_URI' ) );
 		$this->uri = urldecode( $this->uri );
-		$this->uri = trim( $this->uri ), '/' );
+		$this->uri = trim( $this->uri, '/' );
 
 		// Complete request uri.
 		$this->full_uri = $this->uri;

--- a/includes/modules/redirections/class-watcher.php
+++ b/includes/modules/redirections/class-watcher.php
@@ -197,7 +197,6 @@ class Watcher {
 		Cache::purge_by_object_id( $object_id, $type );
 		if ( $from_url ) {
 			$from_url = parse_url( $from_url, PHP_URL_PATH );
-			$from_url = Redirection::strip_subdirectory( $from_url );
 			Cache::add(
 				[
 					'from_url'       => $from_url,
@@ -274,7 +273,7 @@ class Watcher {
 	 * @return string
 	 */
 	private function get_site_path() {
-		$path = parse_url( get_site_url(), PHP_URL_PATH );
+		$path = parse_url( get_home_url(), PHP_URL_PATH );
 		if ( $path ) {
 			return rtrim( $path, '/' ) . '/';
 		}

--- a/includes/modules/rich-snippet/snippets/class-product.php
+++ b/includes/modules/rich-snippet/snippets/class-product.php
@@ -92,7 +92,7 @@ class Product implements Snippet {
 	 * @return array
 	 */
 	public static function get_seller( $jsonld ) {
-		$site_url = site_url();
+		$site_url = home_url();
 		$type     = Helper::get_settings( 'titles.knowledgegraph_type' );
 		$seller   = [
 			'@type' => 'person' === $type ? 'Person' : 'Organization',

--- a/includes/modules/robots-txt/class-robots-txt.php
+++ b/includes/modules/robots-txt/class-robots-txt.php
@@ -101,9 +101,8 @@ class Robots_Txt {
 		if ( 0 === $public ) {
 			$default .= "Disallow: /\n";
 		} else {
-			$site_url = parse_url( site_url() );
-			$default .= "Disallow: /wp-admin/\n";
-			$default .= "Allow: /wp-admin/admin-ajax.php\n";
+			$default .= "Disallow: " . admin_url() . "\n";
+			$default .= "Allow: " . admin_url('admin-ajax.php') . "\n";
 		}
 
 		return [

--- a/includes/modules/robots-txt/class-robots-txt.php
+++ b/includes/modules/robots-txt/class-robots-txt.php
@@ -102,7 +102,7 @@ class Robots_Txt {
 			$default .= "Disallow: /\n";
 		} else {
 			$default .= "Disallow: " . admin_url() . "\n";
-			$default .= "Allow: " . admin_url('admin-ajax.php') . "\n";
+			$default .= "Allow: " . admin_url( 'admin-ajax.php' ) . "\n";
 		}
 
 		return [

--- a/includes/modules/search-console/class-sitemaps.php
+++ b/includes/modules/search-console/class-sitemaps.php
@@ -133,7 +133,7 @@ class Sitemaps {
 		}
 
 		// Normalize URLs.
-		$this_site     = trailingslashit( site_url( '', 'http' ) );
+		$this_site     = trailingslashit( home_url( '', 'http' ) );
 		$selected_site = trailingslashit( str_replace( 'https://', 'http://', Client::get()->profile ) );
 
 		// Check if site URL matches.

--- a/includes/settings/titles/local.php
+++ b/includes/settings/titles/local.php
@@ -48,6 +48,6 @@ $cmb->add_field(
 		'type'    => 'text',
 		'name'    => esc_html__( 'URL', 'rank-math' ),
 		'desc'    => esc_html__( 'URL of the item.', 'rank-math' ),
-		'default' => site_url(),
+		'default' => home_url(),
 	]
 );


### PR DESCRIPTION
- fix(redirections): Replace usage of `site_url()` with `home_url()`
- chore(redirections): Remove the `Redirections::strip_subdirectory` method as it no longer necessary
- fix(product): Replace usage of `site_url()` with `home_url()` in product schema
- fix(robots): Make proper use of `admin_url()` in the default robot entries
- chore(robots): Remove unused `$site_url` variable
- fix(sitemap): Replace usage of `site_url()` with `home_url()`
- fix(titles): Replace usage of `site_url()` with `home_url()` in the local metabox