### PR TITLE
Fixed #27: Stop redirecting WP admin location fallbacks

### DIFF
--- a/includes/modules/redirections/class-redirector.php
+++ b/includes/modules/redirections/class-redirector.php
@@ -282,7 +282,9 @@ class Redirector {
 	 * @codeCoverageIgnore
 	 */
 	private function fallback() {
-		if ( ! is_404() ) {
+		$wp_redirect_admin_locations = ['login', 'admin', 'dashboard'];
+
+		if ( ! is_404() || in_array($this->uri, $wp_redirect_admin_locations) ) {
 			return;
 		}
 

--- a/includes/modules/redirections/views/options.php
+++ b/includes/modules/redirections/views/options.php
@@ -25,7 +25,7 @@ $cmb->add_field(
 		'id'      => 'redirections_fallback',
 		'type'    => 'radio',
 		'name'    => esc_html__( 'Fallback Behavior', 'rank-math' ),
-		'desc'    => esc_html__( 'If nothing similar is found, this behavior will be applied.', 'rank-math' ) . ' ' . esc_html__( 'Note, if nothing is not found but the requested URL ends with "/login", "/admin", or "/dashboard", WordPress will automatically redirect to these locations within the WordPress admin area.', 'rank-math' ),
+		'desc'    => esc_html__( 'If nothing similar is found, this behavior will be applied.', 'rank-math' ) . ' ' . esc_html__( 'Note, if nothing is found but the requested URL ends with "/login", "/admin", or "/dashboard", WordPress will automatically redirect to these locations within the WordPress admin area.', 'rank-math' ),
 		'options' => [
 			'default'  => esc_html__( 'Default 404', 'rank-math' ),
 			'homepage' => esc_html__( 'Redirect to Homepage', 'rank-math' ),

--- a/includes/modules/redirections/views/options.php
+++ b/includes/modules/redirections/views/options.php
@@ -25,7 +25,7 @@ $cmb->add_field(
 		'id'      => 'redirections_fallback',
 		'type'    => 'radio',
 		'name'    => esc_html__( 'Fallback Behavior', 'rank-math' ),
-		'desc'    => esc_html__( 'If nothing similar is found, this behavior will be applied.', 'rank-math' ),
+		'desc'    => esc_html__( 'If nothing similar is found, this behavior will be applied.', 'rank-math' ) . ' ' . esc_html__( 'Note, if nothing is not found but the requested URL ends with "/login", "/admin", or "/dashboard", WordPress will automatically redirect to these locations within the WordPress admin area.', 'rank-math' ),
 		'options' => [
 			'default'  => esc_html__( 'Default 404', 'rank-math' ),
 			'homepage' => esc_html__( 'Redirect to Homepage', 'rank-math' ),


### PR DESCRIPTION
Closes/Fixes #27 

The redirect fallback setting did not take WP's admin fallback redirects into account. WP's admin fallbacks can be found here: https://developer.wordpress.org/reference/functions/wp_redirect_admin_locations/