### PR TITLE
Introduce the filter hook `rank_math/frontend/breadcrumb/is_using_shop_base`

### DIFF
--- a/includes/frontend/class-breadcrumbs.php
+++ b/includes/frontend/class-breadcrumbs.php
@@ -473,14 +473,32 @@ class Breadcrumbs {
 	 * Prepend the shop page to the shop trail.
 	 */
 	private function prepend_shop_page() {
-		$permalinks   = wc_get_permalink_structure();
 		$shop_page_id = wc_get_page_id( 'shop' );
 		$shop_page    = get_post( $shop_page_id );
 
 		// If permalinks contain the shop page in the URI prepend the breadcrumb with shop.
-		if ( $shop_page_id && $shop_page && isset( $permalinks['product_base'] ) && strstr( $permalinks['product_base'], '/' . $shop_page->post_name ) && intval( get_option( 'page_on_front' ) ) !== $shop_page_id ) {
+		if ( $shop_page_id && $shop_page && $this->is_using_shop_base( $shop_page ) && intval( get_option( 'page_on_front' ) ) !== $shop_page_id ) {
 			$this->add_crumb( $this->get_breadcrumb_title( 'post', $shop_page_id, get_the_title( $shop_page ) ), get_permalink( $shop_page ) );
 		}
+	}
+
+	/**
+	 * Checks if the permalinks product base is using the shop base.
+	 *
+	 * @param \WP_Post $shop_page The shop page.
+	 *
+	 * @return bool
+	 */
+	private function is_using_shop_base( $shop_page ) {
+		$permalinks         = wc_get_permalink_structure();
+		$is_using_shop_base = isset( $permalinks['product_base'] ) && strstr( $permalinks['product_base'], '/' . $shop_page->post_name );
+
+		/**
+		 * Allows to filter the "is using shop base" condition.
+		 *
+		 * @param bool True if using shop base or false otherwise.
+		 */
+		return $this->do_filter( 'frontend/breadcrumb/is_using_shop_base', $is_using_shop_base );
 	}
 
 	/**


### PR DESCRIPTION
We (WPML) need this filter to fix [this issue](https://wpml.org/errata/rank-math-seo-woocommerce-missing-shop-breadcrumbs/) in a smarter way.

And this is how we are planning to use this new filter hook (POF):

```php
add_filter( 'rank_math/frontend/breadcrumb/is_using_shop_base', function( $isUsingShopBase ) {
		if ( $isUsingShopBase ) {
			return $isUsingShopBase;
		}

		$defaultShop = wpml_collect( Translations::get( wc_get_page_id( 'shop' ), 'post_page' ) )
			->first( Obj::prop( 'original' ) );
		$productBase = Obj::prop( 'product_base', wc_get_permalink_structure() );

		return $productBase === '/' . get_post( Obj::prop( 'element_id', $defaultShop ) )->post_name;
	}
```

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlwpseo-156