### PR TITLE
(fix) Fix typo

### DIFF
--- a/includes/modules/analytics/class-summary.php
+++ b/includes/modules/analytics/class-summary.php
@@ -50,7 +50,7 @@ class Summary {
 			$stats = (object) [
 				'clicks'      => 0,
 				'impressions' => 0,
-				'postions'    => 0,
+				'position'    => 0,
 			];
 		}
 


### PR DESCRIPTION
Fix a typo resulting in 

```php
Undefined property: stdClass::$position
```