### PR TITLE
fix for query strings attached incorrectly

### DIFF
--- a/includes/modules/redirections/class-redirector.php
+++ b/includes/modules/redirections/class-redirector.php
@@ -142,7 +142,12 @@ class Redirector {
 		$this->do_debugging();
 
 		if ( true === $this->do_filter( 'redirection/add_query_string', true ) && Str::is_non_empty( $this->query_string ) ) {
-			$this->redirect_to .= '?' . $this->query_string;
+			// Check if redirect_to Url contains query string
+			if(strpos($this->redirect_to, '?') !== false){
+				$this->redirect_to .= '&' . $this->query_string;
+			} else{
+				$this->redirect_to .= '?' . $this->query_string;
+			}
 		}
 
 		if ( wp_redirect( esc_url_raw( $this->redirect_to ), $header_code, $this->get_redirect_header() ) ) { // phpcs:ignore


### PR DESCRIPTION
If the redirect_to URL already contains query string parameters, the query string forwarded from the source URL gets attached incorrectly like this:
www.targeturl.com/?redirect_to=string?source=string
It should be: www.targeturl.com/?redirect_to=string&source=string

This pull request fixes this problem.

