### PR TITLE
chore: fix Paper::get() return type.

### DIFF
--- a/includes/frontend/paper/class-paper.php
+++ b/includes/frontend/paper/class-paper.php
@@ -30,7 +30,7 @@ class Paper {
 	/**
 	 * Hold the class instance.
 	 *
-	 * @var object
+	 * @var self
 	 */
 	private static $instance = null;
 
@@ -79,7 +79,7 @@ class Paper {
 	/**
 	 * Initialize object
 	 *
-	 * @return object Post|Term|User.
+	 * @return self Post|Term|User.
 	 */
 	public static function get() {
 		if ( ! is_null( self::$instance ) ) {


### PR DESCRIPTION
Changes the variable type of `Paper::$instance` and the return type of `Paper::get()` to properly return an instance of the `Paper` object, fixing annoying PHPStan bugs when extending Rank Math.