### PR TITLE
Fixed #159: Tags(post and product) and product attributes have empty href attribute

### DIFF
--- a/includes/modules/sitemap/html-sitemap/class-terms.php
+++ b/includes/modules/sitemap/html-sitemap/class-terms.php
@@ -148,7 +148,7 @@ class Terms {
 		$output = [];
 		foreach ( $terms as $term ) {
 			$output[] = '<li class="rank-math-html-sitemap__item">'
-				. '<a href="' . esc_url( $this->get_term_link( (int) $term->term_id, get_taxonomy( $taxonomy ) ) ) . '" class="rank-math-html-sitemap__link">'
+				. '<a href="' . esc_url( $this->get_term_link( (int) $term->term_id, $taxonomy ) ) . '" class="rank-math-html-sitemap__link">'
 				. esc_html( $this->get_term_title( $term, $taxonomy ) )
 				. '</a>'
 				. '</li>';


### PR DESCRIPTION
![Screenshot from 2023-04-08 11-59-48](https://user-images.githubusercontent.com/22325357/230713186-7651acef-d76d-468e-911f-27422d717c0d.png)

[Closes/Fixes #159]