### PR TITLE
Fixed #161: Empty author archive in HTML sitemap

### DIFF
--- a/includes/modules/sitemap/html-sitemap/class-authors.php
+++ b/includes/modules/sitemap/html-sitemap/class-authors.php
@@ -67,7 +67,7 @@ class Authors extends Author {
 			'orderby' => $sort['field'],
 			'order'   => $sort['order'],
 		];
-		$args     = $this->do_filter( 'sitemap/author/query', wp_parse_args( array( 'posts_per_page' => -1 ), $defaults ) );
+		$args     = $this->do_filter( 'sitemap/author/query', wp_parse_args( [ 'posts_per_page' => -1 ], $defaults ) );
 		$users    = $this->get_users( $args );
 
 		if ( empty( $users ) ) {

--- a/includes/modules/sitemap/html-sitemap/class-authors.php
+++ b/includes/modules/sitemap/html-sitemap/class-authors.php
@@ -31,11 +31,11 @@ class Authors extends Author {
 	 */
 	private function get_authors() {
 		$sort_map = [
-			'published' => [
+			'published'    => [
 				'field' => 'user_registered',
 				'order' => 'DESC',
 			],
-			'modified'  => [
+			'modified'     => [
 				'field' => 'user_registered',
 				'order' => 'DESC',
 			],
@@ -43,7 +43,7 @@ class Authors extends Author {
 				'field' => 'display_name',
 				'order' => 'ASC',
 			],
-			'post_id' => [
+			'post_id'      => [
 				'field' => 'ID',
 				'order' => 'DESC',
 			],

--- a/includes/modules/sitemap/html-sitemap/class-authors.php
+++ b/includes/modules/sitemap/html-sitemap/class-authors.php
@@ -50,7 +50,7 @@ class Authors extends Author {
 		];
 
 		$sort_setting = Helper::get_settings( 'sitemap.html_sitemap_sort' );
-		$sort = ( isset( $sort_map[ $sort_setting ] ) ) ? $sort_map[ $sort_setting ] : $sort_map['published'];
+		$sort         = ( isset( $sort_map[ $sort_setting ] ) ) ? $sort_map[ $sort_setting ] : $sort_map['published'];
 
 		/**
 		 * Filter: 'rank_math/sitemap/html_sitemap/sort_items' - Allow changing the sort order of the HTML sitemap.

--- a/includes/modules/sitemap/html-sitemap/class-authors.php
+++ b/includes/modules/sitemap/html-sitemap/class-authors.php
@@ -70,15 +70,15 @@ class Authors extends Author {
 		 * @var string $empty Empty string (unused).
 		 */
 		$sort     = $this->do_filter( 'sitemap/html_sitemap/sort_items', $sort, 'authors', '' );
-		$defaults = array(
+		$defaults = [
 			'orderby' => $sort['field'],
 			'order'   => $sort['order'],
-		);
+		];
 		$args     = $this->do_filter( 'sitemap/author/query', wp_parse_args( array( 'posts_per_page' => -1 ), $defaults ) );
 		$users    = $this->get_users( $args );
 
 		if ( empty( $users ) ) {
-			return array();
+			return [];
 		}
 
 		return $users;

--- a/includes/modules/sitemap/html-sitemap/class-authors.php
+++ b/includes/modules/sitemap/html-sitemap/class-authors.php
@@ -25,13 +25,6 @@ class Authors extends Author {
 	use Hooker;
 
 	/**
-	 * The constructor.
-	 */
-	public function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * Get all authors.
 	 *
 	 * @return array

--- a/includes/modules/sitemap/html-sitemap/class-sitemap.php
+++ b/includes/modules/sitemap/html-sitemap/class-sitemap.php
@@ -103,7 +103,7 @@ class Sitemap extends Taxonomy {
 		 * Filter the setting of excluding empty terms from the XML sitemap.
 		 *
 		 * @param boolean $exclude        Defaults to true.
-		 * @param array   $taxonomies Array of names for the taxonomies being processed.
+		 * @param array   $taxonomies     Array of names for the taxonomies being processed.
 		 */
 		$hide_empty = $this->do_filter( 'sitemap/exclude_empty_terms', true, $taxonomies );
 
@@ -135,7 +135,7 @@ class Sitemap extends Taxonomy {
 				$sitemap = $this->get_generator( 'terms' )->generate_sitemap(
 					$taxonomy,
 					$show_dates,
-					array( 'hide_empty' => $hide_empty )
+					[ 'hide_empty' => $hide_empty ]
 				);
 				$this->set_cache( $taxonomy, $sitemap );
 				$output[] = $sitemap;
@@ -228,6 +228,8 @@ class Sitemap extends Taxonomy {
 
 	/**
 	 * Show sitemap on a page (after content).
+	 *
+	 * @param mixed $content The page content.
 	 */
 	public function show_on_page( $content ) {
 		if ( ! is_page() ) {

--- a/includes/modules/sitemap/html-sitemap/class-sitemap.php
+++ b/includes/modules/sitemap/html-sitemap/class-sitemap.php
@@ -11,6 +11,7 @@
 namespace RankMath\Sitemap\Html;
 
 use RankMath\Helper;
+use RankMath\Sitemap\Providers\Taxonomy;
 use RankMath\Traits\Hooker;
 use RankMath\Sitemap\Cache;
 
@@ -19,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Sitemap class.
  */
-class Sitemap {
+class Sitemap extends Taxonomy {
 
 	use Hooker;
 
@@ -95,7 +96,17 @@ class Sitemap {
 	 */
 	public function get_output() {
 		$post_types = self::get_post_types();
-		$taxonomies = self::get_taxonomies();
+		$taxonomies = Helper::get_accessible_taxonomies();
+		$taxonomies = array_filter( $taxonomies, [ $this, 'handles_type' ] );
+
+		/**
+		 * Filter the setting of excluding empty terms from the XML sitemap.
+		 *
+		 * @param boolean $exclude        Defaults to true.
+		 * @param array   $taxonomies Array of names for the taxonomies being processed.
+		 */
+		$hide_empty = $this->do_filter( 'sitemap/exclude_empty_terms', true, $taxonomies );
+
 		$show_dates = Helper::get_settings( 'sitemap.html_sitemap_show_dates' );
 		$output     = [];
 
@@ -112,16 +123,23 @@ class Sitemap {
 			$output[] = $sitemap;
 		}
 
-		foreach ( $taxonomies as $taxonomy ) {
-			$cached = $this->get_cache( $taxonomy );
-			if ( ! empty( $cached ) ) {
-				$output[] = $cached;
-				continue;
-			}
+		if ( ! empty( $taxonomies ) ) {
+			foreach ( $taxonomies as $taxonomy => $object ) {
 
-			$sitemap = $this->get_generator( 'terms' )->generate_sitemap( $taxonomy, $show_dates );
-			$this->set_cache( $taxonomy, $sitemap );
-			$output[] = $sitemap;
+				$cached = $this->get_cache( $taxonomy );
+				if ( ! empty( $cached ) ) {
+					$output[] = $cached;
+					continue;
+				}
+
+				$sitemap = $this->get_generator( 'terms' )->generate_sitemap(
+					$taxonomy,
+					$show_dates,
+					array( 'hide_empty' => $hide_empty )
+				);
+				$this->set_cache( $taxonomy, $sitemap );
+				$output[] = $sitemap;
+			}
 		}
 
 		if ( $this->should_show_author_sitemap() ) {

--- a/includes/modules/sitemap/html-sitemap/class-terms.php
+++ b/includes/modules/sitemap/html-sitemap/class-terms.php
@@ -93,13 +93,13 @@ class Terms {
 	/**
 	 * Generate the HTML sitemap for a given taxonomy.
 	 *
-	 * @param string $taxonomy Taxonomy name.
+	 * @param string $taxonomy   Taxonomy name.
 	 * @param bool   $show_dates Whether to show dates.
-	 * @param array   $args Array with term query arguments.
+	 * @param array  $args       Array with term query arguments.
 	 *
 	 * @return string
 	 */
-	public function generate_sitemap( $taxonomy, $show_dates, $args = array() ) {
+	public function generate_sitemap( $taxonomy, $show_dates, $args = [] ) {
 		$terms = get_terms( $taxonomy, $args );
 		if ( empty( $terms ) ) {
 			return '';
@@ -140,8 +140,8 @@ class Terms {
 	/**
 	 * Get the term list HTML for non-hierarchical taxonomies.
 	 *
-	 * @param array $terms The terms to output.
-	 * @param bool  $show_dates Whether to show the term dates.
+	 * @param array $terms    The terms to output.
+	 * @param bool  $taxonomy Name of taxonomy object to generate list for.
 	 *
 	 * @return string
 	 */

--- a/includes/modules/sitemap/html-sitemap/class-terms.php
+++ b/includes/modules/sitemap/html-sitemap/class-terms.php
@@ -120,7 +120,7 @@ class Terms {
 	/**
 	 * Get the term list HTML.
 	 *
-	 * @param array  $terms The terms to output.
+	 * @param array  $terms    The terms to output.
 	 * @param object $taxonomy The taxonomy object.
 	 *
 	 * @return string

--- a/includes/modules/sitemap/html-sitemap/class-terms.php
+++ b/includes/modules/sitemap/html-sitemap/class-terms.php
@@ -95,11 +95,12 @@ class Terms {
 	 *
 	 * @param string $taxonomy Taxonomy name.
 	 * @param bool   $show_dates Whether to show dates.
+	 * @param array   $args Array with term query arguments.
 	 *
 	 * @return string
 	 */
-	public function generate_sitemap( $taxonomy, $show_dates ) {
-		$terms = $this->get_terms( $taxonomy );
+	public function generate_sitemap( $taxonomy, $show_dates, $args = array() ) {
+		$terms = get_terms( $taxonomy, $args );
 		if ( empty( $terms ) ) {
 			return '';
 		}

--- a/includes/modules/sitemap/providers/class-author.php
+++ b/includes/modules/sitemap/providers/class-author.php
@@ -150,7 +150,7 @@ class Author implements Provider {
 	 * @param  array $args Arguments to add.
 	 * @return array
 	 */
-	protected function get_users( $args = [] ) {
+	public function get_users( $args = [] ) {
 		$defaults = [
 			'orderby'    => 'meta_value_num',
 			'order'      => 'DESC',


### PR DESCRIPTION
** Screenshots **
| All taxonomies (including empty)| Fixed: Taxonomies related to content (posts) |
| --- | --- |
| ![Screenshot from 2023-04-08 17-30-41](https://user-images.githubusercontent.com/22325357/230726884-fb8f334c-fcfd-487d-b4cb-0038363cd6e1.png) | ![Screenshot from 2023-04-08 17-26-17](https://user-images.githubusercontent.com/22325357/230726890-6f52c7bf-6684-4b51-9fe8-ad0f1b128ec4.png) |

[Closes/Fixes #161]