### PR TITLE
Fixed #190: [404 Monitor] 404 monitor doesn’t include the language slug in the log

### DIFF
--- a/includes/modules/404-monitor/class-monitor.php
+++ b/includes/modules/404-monitor/class-monitor.php
@@ -123,10 +123,7 @@ class Monitor {
 		}
 
 		$uri = untrailingslashit( Helper::get_current_page_url( Helper::get_settings( 'general.404_monitor_ignore_query_parameters' ) ) );
-		$uri = wp_parse_url( $uri );
-		$uri = ( isset( $uri['path'] ) ? $uri['path'] : '' ) . ( isset( $uri['query'] ) ? '?' . $uri['query'] : '' );
-		$uri = isset( $uri[0] ) && '/' === $uri[0] ? mb_substr( $uri, 1 ) : $uri;
-
+		$uri = str_replace( Helper::get_home_url( '/' ), '', $uri );
 		// Check if excluded.
 		if ( $this->is_url_excluded( $uri ) ) {
 			return;

--- a/includes/modules/404-monitor/class-monitor.php
+++ b/includes/modules/404-monitor/class-monitor.php
@@ -123,7 +123,9 @@ class Monitor {
 		}
 
 		$uri = untrailingslashit( Helper::get_current_page_url( Helper::get_settings( 'general.404_monitor_ignore_query_parameters' ) ) );
-		$uri = str_replace( home_url( '/' ), '', $uri );
+		$uri = wp_parse_url( $uri );
+		$uri = ( isset( $uri['path'] ) ? $uri['path'] : '' ) . ( isset( $uri['query'] ) ? '?' . $uri['query'] : '' );
+		$uri = isset( $uri[0] ) && '/' === $uri[0] ? mb_substr( $uri, 1 ) : $uri;
 
 		// Check if excluded.
 		if ( $this->is_url_excluded( $uri ) ) {


### PR DESCRIPTION
Replaced the code str_replace 
Parsed the 404 URL and mb_substr to find the language slug
[ Closes/Fixes #190]