### PR TITLE
Fixed #192 [Redirections/Contains & Start With] Contains and Starts With matching doesn’t work when there is a trailing slash in the source URL

### DIFF
--- a/includes/modules/redirections/class-db.php
+++ b/includes/modules/redirections/class-db.php
@@ -328,6 +328,14 @@ class DB {
 			return false;
 		}
 
+		if ( ! empty( $args['sources'] ) ) {
+			foreach ( $args['sources'] as $key => $value ) {
+				if ( 'start' === $value['comparison'] || 'contains' === $value['comparison'] ) {
+					$args['sources'][ $key ]['pattern'] = untrailingslashit( $value['pattern'] );
+				}
+			}
+		}
+
 		$args = wp_parse_args(
 			$args,
 			[
@@ -362,6 +370,14 @@ class DB {
 			return false;
 		}
 
+		if ( ! empty( $args['sources'] ) ) {
+			foreach ( $args['sources'] as $key => $value ) {
+				if ( 'start' === $value['comparison'] || 'contains' === $value['comparison'] ) {
+					$args['sources'][ $key ]['pattern'] = untrailingslashit( $value['pattern'] );
+				}
+			}
+		}
+		
 		$args = wp_parse_args(
 			$args,
 			[

--- a/includes/modules/redirections/class-db.php
+++ b/includes/modules/redirections/class-db.php
@@ -186,7 +186,7 @@ class DB {
 				$compare_uri = untrailingslashit( $compare_uri );
 			}
 			
-			if ( 'contains' === $source['comparison'] || 'start' === $source['comparison'] ) {
+			if ( 'contains' === $source['comparison'] || 'start' === $source['comparison'] || 'end' === $source['comparison'] ) {
 				$source['pattern'] = untrailingslashit( $source['pattern'] );
 			}
 
@@ -364,8 +364,7 @@ class DB {
 	public static function update( $args = [] ) {
 		if ( empty( $args ) ) {
 			return false;
-		}
-		
+		}		
 		$args = wp_parse_args(
 			$args,
 			[

--- a/includes/modules/redirections/class-db.php
+++ b/includes/modules/redirections/class-db.php
@@ -185,6 +185,10 @@ class DB {
 			if ( 'exact' === $source['comparison'] ) {
 				$compare_uri = untrailingslashit( $compare_uri );
 			}
+			
+			if ( 'contains' === $source['comparison'] || 'start' === $source['comparison'] ) {
+				$source['pattern'] = untrailingslashit( $source['pattern'] );
+			}
 
 			if ( 'exact' === $source['comparison'] && isset( $source['ignore'] ) && 'case' === $source['ignore'] && strtolower( $source['pattern'] ) === strtolower( $compare_uri ) ) {
 				return true;
@@ -328,14 +332,6 @@ class DB {
 			return false;
 		}
 
-		if ( ! empty( $args['sources'] ) ) {
-			foreach ( $args['sources'] as $key => $value ) {
-				if ( 'start' === $value['comparison'] || 'contains' === $value['comparison'] ) {
-					$args['sources'][ $key ]['pattern'] = untrailingslashit( $value['pattern'] );
-				}
-			}
-		}
-
 		$args = wp_parse_args(
 			$args,
 			[
@@ -368,14 +364,6 @@ class DB {
 	public static function update( $args = [] ) {
 		if ( empty( $args ) ) {
 			return false;
-		}
-
-		if ( ! empty( $args['sources'] ) ) {
-			foreach ( $args['sources'] as $key => $value ) {
-				if ( 'start' === $value['comparison'] || 'contains' === $value['comparison'] ) {
-					$args['sources'][ $key ]['pattern'] = untrailingslashit( $value['pattern'] );
-				}
-			}
 		}
 		
 		$args = wp_parse_args(


### PR DESCRIPTION
Used untrailedslashit to remove slash from serialized value to make the comparison work  
[ Closes/Fixes #192]