### PR TITLE
Fixed #198: [Analytics] Failing to create new GSC and GA properties

### DIFF
--- a/assets/admin/src/search-console.js
+++ b/assets/admin/src/search-console.js
@@ -10,6 +10,7 @@ import { get, map, isEmpty, isUndefined } from 'lodash'
  * Internal Dependencies
  */
 import ajax from '@helpers/ajax'
+import addNotice from '@helpers/addNotice'
 import { __ } from '@wordpress/i18n'
 
 class SearchConsole {
@@ -25,6 +26,9 @@ class SearchConsole {
 
 			ajax( 'google_check_all_services' ).done( ( response ) => {
 				this.response = response
+				if ( response && ! response.success ) {
+					addNotice( response.error, 'error', this.divtoShowerror )
+				}
 				this.fillSelect()
 				this.accordions.removeClass( 'locked' )
 			} )

--- a/includes/admin/wizard/views/search-console-ui.php
+++ b/includes/admin/wizard/views/search-console-ui.php
@@ -99,7 +99,7 @@ $console_classes = Helper::classnames(
 		</div>
 
 
-		<div class="cmb-row cmb-type-toggle">
+		<div class="cmb-row cmb-type-toggle rank_math_no_gsc_ga">
 			<div class="cmb-td">
 				<label class="cmb2-toggle">
 					<input type="checkbox" class="regular-text notrack" name="enable-index-status" id="enable-index-status" value="on"<?php checked( $is_index_status_enabled ); ?> <?php echo disabled( ! $is_profile_connected ) ?>>

--- a/includes/modules/analytics/class-ajax.php
+++ b/includes/modules/analytics/class-ajax.php
@@ -364,6 +364,8 @@ class AJAX {
 		if ( ! empty( $result['accounts'] ) ) {
 			$result['hasAnalytics']         = true;
 			$result['hasAnalyticsProperty'] = $this->is_site_in_analytics( $result['accounts'] );
+		} else {
+			$this->error( esc_html__( 'Check the Google account connected. It seems like there is no Google analytics enabled with the account', 'rank-math-pro' ) );
 		}
 
 		$result = apply_filters( 'rank_math/analytics/check_all_services', $result );

--- a/languages/rank-math.pot
+++ b/languages/rank-math.pot
@@ -6107,3 +6107,6 @@ msgstr ""
 
 msgid "11-50 Positions"
 msgstr ""
+
+msgid "Check the Google account connected. It seems like there is no Google analytics enabled with the account"
+msgstr ""


### PR DESCRIPTION
Shows error if GA is not enabled with the account