### PR TITLE
Adding a new "instant_indexing/indexnow_payload" filter

### DIFF
--- a/includes/modules/instant-indexing/class-api.php
+++ b/includes/modules/instant-indexing/class-api.php
@@ -331,12 +331,12 @@ class Api {
 	 */
 	private function get_payload( $urls ) {
 		return wp_json_encode(
-			[
+			$this->do_filter( 'instant_indexing/indexnow_payload', [
 				'host'        => $this->get_host(),
 				'key'         => $this->get_key(),
 				'keyLocation' => $this->get_key_location( 'request_payload' ),
 				'urlList'     => (array) $urls,
-			]
+			])
 		);
 	}
 


### PR DESCRIPTION
I'm running my WP behind a proxy ; so I need to update my host, my key AND the urls being sent to IndexNow. (so they can match my "front" domain)

I'm also using WPML; which means I'm dealing with multiples domain names for the same WP instance,

With the current filters ; It's very hard to "transform" the query being sent to IndexNow ; almost impossible to make it work .

Or if I find a way to make it work for the API , then it won't work for the "publish" hook (when a post is published) ; or when dealing with a "manual" submission