### PR TITLE
Leverage the new script API strategy feature to defer front end scripts

### DIFF
--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -122,8 +122,24 @@ class Frontend {
 			return;
 		}
 
+		$script_in_footer = true;
+		// Since WordPress 6.4 we can safely move front end scripts to header and add a defer attribute.
+		if ( version_compare( get_bloginfo( 'version' ), '6.4', '>=' ) ) {
+			$script_in_footer = array(
+				'strategy' => 'defer',
+				'in_footer' => false,
+			);
+		} elseif ( version_compare( get_bloginfo( 'version' ), '6.3', '>=' ) ) {
+			// In version 6.3 we can use defer, but moving scripts to the header could create a regression
+			// if there is a dependent script that is not deferred. See https://core.trac.wordpress.org/ticket/59599.
+			$script_in_footer = array(
+				'strategy' => 'defer',
+				'in_footer' => true,
+			);
+		}
+
 		wp_enqueue_style( 'rank-math', rank_math()->assets() . 'css/rank-math.css', null, rank_math()->version );
-		wp_enqueue_script( 'rank-math', rank_math()->assets() . 'js/rank-math.js', [ 'jquery' ], rank_math()->version, true );
+		wp_enqueue_script( 'rank-math', rank_math()->assets() . 'js/rank-math.js', [ 'jquery' ], rank_math()->version, $script_in_footer );
 
 		if ( is_singular() ) {
 			Helper::add_json( 'objectID', Post::get_page_id() );


### PR DESCRIPTION
This PR adds the `defer` attribute to the front end script `js/rank-math.js` enqueued in `includes/frontend/class-frontend.php`.

## Context
WordPress introduced a new strategy feature in the Script API in version 6.3. See [this post](https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/) for more details. Even though `js/rank-math.js` is only enqueued when the wp-admin bar is shown, it still seems helpful to leverage `defer` and switch away from the boolean `in_footer` setting.

Note that this PR includes a version check and slightly different behavior for 6.3 vs. 6.4 where a potential regression is fixed. 


## Summary
* Detects WordPress version, using new approach when available and falling back to existing approach
* Keeps script in footer for 6.3 while moving to header in 6.4; see https://core.trac.wordpress.org/ticket/59599 for details on why.

## Test instructions

* Verify that the script tag includes the defer attribute before and at WordPress 6.3. 
* With WordPress 6.3 the script tag will print in the footer and also contain `data-wp-strategy="defer` indicating the API has added the attribute.
* With WordPress 6.4 the tag will print in the header.
