### PR TITLE
Check that the class is actually a user

### DIFF
--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -42,6 +42,9 @@ class User extends Metadata {
 		if ( empty( $user ) ) {
 			return null;
 		}
+                if ( ! is_a( $user, 'WP_User') ) {
+                        return null;
+                }
 
 		if ( isset( self::$objects[ $user ] ) && 'user' === self::$objects[ $user ]->meta_type ) {
 			return self::$objects[ $user ];


### PR DESCRIPTION
Adds a check before getting the user meta_type and ensuring it's a user before proceeding with the user.

In some instances, Rank Math is catching a custom post type if other plugins are involved. For example, sometimes the post object is being fed into the class-user, and this object does not have a 'meta_type', causing a fatal error in PHP 8+.