### PR TITLE
fix: create the missing enabled modules db tables when import settings

### DIFF
--- a/includes/admin/class-import-export.php
+++ b/includes/admin/class-import-export.php
@@ -458,6 +458,8 @@ class Import_Export implements Runner {
 		// Import options.
 		$down = $this->set_options( $data );
 
+		Helper::update_modules( array_flip( $data['modules'] ) );
+
 		// Import capabilities.
 		if ( ! empty( $data['role-manager'] ) ) {
 			$down = true;


### PR DESCRIPTION
Execute update modules when importing settings to create the missing enabled modules db tables, like: `wp_rank_math_redirections`.