### PR TITLE
refactor: Warning: Attempt to read property "ID" on int

### DIFF
--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -268,16 +268,17 @@ class Frontend {
 		$no_follow = true === $no_follow ? 'rel="nofollow" ' : '';
 
 		$author_link = '';
+		$image       = '';
 		if ( is_object( $post ) ) {
 			$author_link = '<a ' . $no_follow . 'href="' . esc_url( get_author_posts_url( $post->post_author ) ) . '">' . esc_html( get_the_author() ) . '</a>';
+
+			// Featured image.
+			$image = Helper::get_thumbnail_with_fallback( $post->ID, 'full' );
+			$image = isset( $image[0] ) ? '<img src="' . $image[0] . '" style="display: block; margin: 1em auto">' : '';
 		}
 		$post_link      = '<a ' . $no_follow . 'href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a>';
 		$blog_link      = '<a ' . $no_follow . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . esc_html( get_bloginfo( 'name' ) ) . '</a>';
 		$blog_desc_link = '<a ' . $no_follow . 'href="' . esc_url( get_bloginfo( 'url' ) ) . '">' . esc_html( get_bloginfo( 'name' ) ) . ' - ' . esc_html( get_bloginfo( 'description' ) ) . '</a>';
-
-		// Featured image.
-		$image = Helper::get_thumbnail_with_fallback( $post->ID, 'full' );
-		$image = isset( $image[0] ) ? '<img src="' . $image[0] . '" style="display: block; margin: 1em auto">' : '';
 
 		$content = stripslashes( trim( $content ) );
 		$content = str_replace( '%AUTHORLINK%', $author_link, $content );


### PR DESCRIPTION
This fixes #298

Moved the definition of $image into `if ( is_object( $post ) ) {...}` this prevents my reported error `Warning: Attempt to read property "ID" on int` for `$image = Helper::get_thumbnail_with_fallback( $post->ID, 'full' );` 

The error happened in case `global $post` was not an object, which most likely will be an integer with value `0` another option would have been to use `get_the_ID()` since this adds checks by design as well, but since we already have a condition here, I kept the general structure of the function. 