### PR TITLE
Fix deprecation warning when SEO position is missing in summary

### DIFF
--- a/includes/modules/analytics/class-summary.php
+++ b/includes/modules/analytics/class-summary.php
@@ -120,9 +120,9 @@ class Summary {
 		];
 
 		$stats->position = [
-			'total'      => (float) \number_format( $stats->position, 2 ),
-			'previous'   => (float) \number_format( $old_stats->position, 2 ),
-			'difference' => (float) \number_format( $stats->position - $old_stats->position, 2 ),
+			'total'      => (float) \number_format( $stats->position ?? 0, 2 ),
+			'previous'   => (float) \number_format( $old_stats->position ?? 0, 2 ),
+			'difference' => (float) \number_format( ($stats->position ?? 0) - ($old_stats->position ?? 0), 2 ),
 		];
 
 		$stats->keywords = $this->get_keywords_summary();


### PR DESCRIPTION
Fixes the following deprecation warnings:

```
PHP Deprecated:  number_format(): Passing null to parameter #1 ($num) of type float is deprecated in wp-content/plugins/seo-by-rank-math/includes/modules/analytics/class-summary.php on line 123
PHP Deprecated:  number_format(): Passing null to parameter #1 ($num) of type float is deprecated in wp-content/plugins/seo-by-rank-math/includes/modules/analytics/class-summary.php on line 124
```

-R