### PR TITLE
Fixed #108: harden schema processing against non-array data

### DIFF
--- a/includes/modules/schema/class-frontend.php
+++ b/includes/modules/schema/class-frontend.php
@@ -70,7 +70,7 @@ class Frontend {
 		$schemas = array_filter(
 			DB::get_schemas( $post->ID ),
 			function ( $schema ) {
-				return ! in_array( $schema['@type'], [ 'WooCommerceProduct', 'EDDProduct' ], true );
+				return is_array( $schema ) && isset( $schema['@type'] ) && ! in_array( $schema['@type'], [ 'WooCommerceProduct', 'EDDProduct' ], true );
 			}
 		);
 
@@ -92,6 +92,10 @@ class Frontend {
 	 * @return array
 	 */
 	public function connect_schema_entities( $schemas, $jsonld ) {
+		if ( ! is_array( $schemas ) ) {
+			return [];
+		}
+
 		if ( empty( $schemas ) ) {
 			return $schemas;
 		}
@@ -100,7 +104,12 @@ class Frontend {
 
 		$schema_types = [];
 		foreach ( $schemas as $id => $schema ) {
-			if ( ( ! Str::starts_with( 'schema-', $id ) && 'richSnippet' !== $id ) || ! $schema ) {
+			if ( ! is_array( $schema ) || ! isset( $schema['@type'] ) ) {
+				continue;
+			}
+
+			$id = (string) $id;
+			if ( ! Str::starts_with( 'schema-', $id ) && 'richSnippet' !== $id ) {
 				continue;
 			}
 

--- a/includes/modules/schema/class-jsonld.php
+++ b/includes/modules/schema/class-jsonld.php
@@ -173,7 +173,11 @@ class JsonLD {
 	 * @return array
 	 */
 	private function validate_schema( $data ) {
-		if ( ! is_array( $data ) || empty( $data ) ) {
+		if ( ! is_array( $data ) ) {
+			return [];
+		}
+
+		if ( empty( $data ) ) {
 			return $data;
 		}
 


### PR DESCRIPTION
This PR adds minimal null/type-safety checks in Schema processing to prevent PHP warnings/errors when malformed or non-array schema data is encountered.

Fixes #108