### PR TITLE
Fix: Undefined array key "width" and "height" warnings in JsonLD

### DIFF
--- a/includes/modules/schema/class-jsonld.php
+++ b/includes/modules/schema/class-jsonld.php
@@ -476,8 +476,12 @@ class JsonLD {
 			return;
 		}
 
-		$entity['logo']['width']  = $attachment['width'];
-		$entity['logo']['height'] = $attachment['height'];
+		if ( isset( $attachment['width'] ) ) {
+			$entity['logo']['width']  = $attachment['width'];
+		}
+		if ( isset( $attachment['height'] ) ) {
+			$entity['logo']['height'] = $attachment['height'];
+		}
 	}
 
 	/**


### PR DESCRIPTION
Added isset() check before accessing $attachment['width'] and $attachment['height'] in add_prop_image() (class-jsonld.php). When the knowledge graph logo is an SVG or lacks metadata in the database, it throws PHP Warnings.