### PR TITLE
fix(schema): guard @type key access to prevent PHP warning

### DIFF
--- a/includes/modules/schema/class-frontend.php
+++ b/includes/modules/schema/class-frontend.php
@@ -70,7 +70,8 @@ class Frontend {
 		$schemas = array_filter(
 			DB::get_schemas( $post->ID ),
 			function ( $schema ) {
-				return ! in_array( $schema['@type'], [ 'WooCommerceProduct', 'EDDProduct' ], true );
+				return is_array( $schema ) && ! empty( $schema['@type'] )
+					&& ! in_array( $schema['@type'], [ 'WooCommerceProduct', 'EDDProduct' ], true );
 			}
 		);
 
@@ -104,7 +105,9 @@ class Frontend {
 				continue;
 			}
 
-			$schema_types[] = $schema['@type'];
+			if ( ! empty( $schema['@type'] ) ) {
+				$schema_types[] = $schema['@type'];
+			}
 			$this->connect_properties( $schema, $id, $jsonld, $schemas );
 			$this->add_main_entity_of_page( $schema, $jsonld );
 			$schemas[ $id ] = $schema;

--- a/includes/modules/schema/class-jsonld.php
+++ b/includes/modules/schema/class-jsonld.php
@@ -337,6 +337,9 @@ class JsonLD {
 		$new_schemas = [];
 
 		foreach ( $schemas as $key => $schema ) {
+			if ( ! is_array( $schema ) || empty( $schema['@type'] ) ) {
+				continue;
+			}
 			$type = is_array( $schema['@type'] ) ? $schema['@type'][0] : $schema['@type'];
 			$type = strtolower( $type );
 			$type = in_array( $type, [ 'musicgroup', 'musicalbum' ], true )


### PR DESCRIPTION
## Summary

Two defensive guards stop PHP `Undefined array key "@type"` warnings from filling error logs when 3rd-party plugins register schema entries without the @type key.

Fixes #338

## Changes

### `includes/modules/schema/class-jsonld.php` — `JsonLD::filter()` loop

**Before:**
```php
foreach ( $schemas as $key => $schema ) {
    $type = is_array( $schema['@type'] ) ? $schema['@type'][0] : $schema['@type'];
```

**After:**
```php
foreach ( $schemas as $key => $schema ) {
    if ( ! is_array( $schema ) || empty( $schema['@type'] ) ) {
        continue;
    }
    $type = is_array( $schema['@type'] ) ? $schema['@type'][0] : $schema['@type'];
```

**Why:** Skip schemas missing @type instead of building a malformed hook name like `snippet/rich_snippet_` for 3rd-party listeners.

### `includes/modules/schema/class-frontend.php` — `Frontend::connect_schema_entities()`

**Before:**
```php
$schema_types[] = $schema['@type'];
```

**After:**
```php
if ( ! empty( $schema['@type'] ) ) {
    $schema_types[] = $schema['@type'];
}
```

**Why:** Only collect the type when it exists. `connect_properties()` and `add_main_entity_of_page()` already have their own @type guards at line 180.

### `includes/modules/schema/class-frontend.php` — `Frontend::add_schema()` (defense-in-depth)

**Before:**
```php
function ( $schema ) {
    return ! in_array( $schema['@type'], [ 'WooCommerceProduct', 'EDDProduct' ], true );
```

**After:**
```php
function ( $schema ) {
    return is_array( $schema ) && ! empty( $schema['@type'] )
        && ! in_array( $schema['@type'], [ 'WooCommerceProduct', 'EDDProduct' ], true );
```

**Why:** Drop non-array and @type-less entries from `DB::get_schemas()` output before processing.

## Testing

**Test 1: No warnings**
1. Set `WP_DEBUG`, `WP_DEBUG_LOG` true in wp-config.php.
2. Visit frontend pages.
3. Confirm no `Undefined array key "@type"` in debug.log.

**Test 2: Valid schemas unchanged**
1. Inspect `<script type="application/ld+json">` on frontend.
2. All existing entries (`Article`, `WebPage`, `Organization`, etc.) present.

**Test 3: Malformed schema filtered**
1. Register a schema without @type via `rank_math/json_ld` filter (simulates 3rd-party).
2. Confirm no warning + entry silently filtered from output.
3. Other schemas remain.