### PR TITLE
fix: Action Scheduler fatal when WooCommerce is active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
-- Improved: Moved [Role Manager](https://rankmath.com/kb/role-manager/) code to React. Now it loads blazing fast. We will gruadually make other modules load fast as well. 
+- Fixed: Action Scheduler fatal error that occurred at shutdown when WooCommerce was active. Rank Math now defers to WooCommerce's bundled Action Scheduler instead of loading its own copy eagerly. See [#337](https://github.com/rankmath/seo-by-rank-math/issues/337).
+- Improved: Moved [Role Manager](https://rankmath.com/kb/role-manager/) code to React. Now it loads blazing fast. We will gruadually make other modules load fast as well.
 - Fixed: Update button state in the [Elementor editor](https://rankmath.com/blog/elementor-seo/) remained active even without any content changes when the Schema module was enabled
 - Fixed: [Table of Contents Block](https://rankmath.com/kb/table-of-contents-block/) was not working with Full Site editing templates
 - Fixed: [Organization name variable](https://rankmath.com/kb/variables-in-seo-title-description/#organization-name) `%org_name%` was displaying the site name in the Preview editor instead of the Organization name

--- a/composer.json
+++ b/composer.json
@@ -64,8 +64,7 @@
 		"classmap" : [ "includes/" ],
 		"files": [
 			"vendor/cmb2/cmb2/init.php",
-			"includes/template-tags.php",
-			"vendor/woocommerce/action-scheduler/action-scheduler.php"
+			"includes/template-tags.php"
 		]
 	},
 	"autoload-dev": {

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -486,6 +486,12 @@ class Admin implements Runner {
 	 * @param null $value Null value.
 	 */
 	public function as_exclude_pastdue_actions( $value ) {
+		// Issue #337: if AS is not loaded (e.g. another plugin replaced it),
+		// fall back to the default behavior.
+		if ( ! Helper::is_action_scheduler_available() || ! class_exists( '\ActionScheduler_Store' ) ) {
+			return $value;
+		}
+
 		$query_args = [
 			'date'     => as_get_datetime_object( time() - DAY_IN_SECONDS ),
 			'status'   => \ActionScheduler_Store::STATUS_PENDING,

--- a/includes/helpers/class-conditional.php
+++ b/includes/helpers/class-conditional.php
@@ -448,4 +448,24 @@ trait Conditional {
 	public static function is_edd_active() {
 		return class_exists( 'Easy_Digital_Downloads' );
 	}
+
+	/**
+	 * Is Action Scheduler available (loaded and callable)?
+	 *
+	 * Used to gate call sites that schedule or query actions so they no-op
+	 * gracefully when AS has been removed, replaced, or never loaded. See
+	 * https://github.com/rankmath/seo-by-rank-math/issues/337
+	 *
+	 * @since 1.0.273
+	 *
+	 * @return bool
+	 */
+	public static function is_action_scheduler_available() {
+		return function_exists( 'as_schedule_single_action' )
+			&& function_exists( 'as_schedule_recurring_action' )
+			&& function_exists( 'as_unschedule_action' )
+			&& function_exists( 'as_unschedule_all_actions' )
+			&& function_exists( 'as_has_scheduled_action' )
+			&& function_exists( 'as_enqueue_async_action' );
+	}
 }

--- a/includes/helpers/class-schedule.php
+++ b/includes/helpers/class-schedule.php
@@ -33,6 +33,11 @@ class Schedule {
 	 * @return int The action ID. Zero if there was an error scheduling the action.
 	 */
 	public static function recurring_action( $timestamp, $interval_in_seconds, $hook, $args = [], $group = '', $unique = false, $priority = 10 ) {
+		// Issue #337: bail when AS is missing rather than fatal. See Helper::is_action_scheduler_available().
+		if ( ! Helper::is_action_scheduler_available() ) {
+			return 0;
+		}
+
 		$id = as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group, $unique, $priority );
 
 		if ( ! $id ) {
@@ -58,6 +63,11 @@ class Schedule {
 	 * @return int The action ID. Zero if there was an error scheduling the action.
 	 */
 	public static function single_action( $timestamp, $hook, $args = [], $group = '', $unique = false, $priority = 10 ) {
+		// Issue #337: bail when AS is missing rather than fatal.
+		if ( ! Helper::is_action_scheduler_available() ) {
+			return 0;
+		}
+
 		$id = as_schedule_single_action( $timestamp, $hook, $args, $group, $unique, $priority );
 
 		if ( ! $id ) {
@@ -87,6 +97,11 @@ class Schedule {
 	 * @return int|null The scheduled action ID if a scheduled action was found, or null if no matching action found.
 	 */
 	public static function unschedule_action( $hook, $args = [], $group = '' ) {
+		// Issue #337: bail when AS is missing rather than fatal.
+		if ( ! Helper::is_action_scheduler_available() ) {
+			return null;
+		}
+
 		$id = as_unschedule_action( $hook, $args, $group );
 
 		if ( ! $id ) {
@@ -111,6 +126,11 @@ class Schedule {
 	 * @return int The action ID. Zero if there was an error scheduling the action.
 	 */
 	public static function async_action( $hook, $args = [], $group = '', $unique = false, $priority = 10 ) {
+		// Issue #337: bail when AS is missing rather than fatal.
+		if ( ! Helper::is_action_scheduler_available() ) {
+			return 0;
+		}
+
 		$id = as_enqueue_async_action( $hook, $args, $group, $unique, $priority );
 
 		if ( ! $id ) {

--- a/includes/modules/analytics/class-analytics-common.php
+++ b/includes/modules/analytics/class-analytics-common.php
@@ -271,7 +271,10 @@ class Analytics_Common {
 			return;
 		}
 
-		as_unschedule_all_actions( 'rank_math/analytics/email_report_event', [], 'rank-math' );
+		// Issue #337: bail when AS is missing rather than fatal.
+		if ( Helper::is_action_scheduler_available() ) {
+			as_unschedule_all_actions( 'rank_math/analytics/email_report_event', [], 'rank-math' );
+		}
 		if ( ! $console_email_reports ) {
 			return;
 		}
@@ -294,7 +297,10 @@ class Analytics_Common {
 			return;
 		}
 
-		as_unschedule_all_actions( 'rank_math/analytics/email_report_event', [], 'rank-math' );
+		// Issue #337: bail when AS is missing rather than fatal.
+		if ( Helper::is_action_scheduler_available() ) {
+			as_unschedule_all_actions( 'rank_math/analytics/email_report_event', [], 'rank-math' );
+		}
 		$values = $cmb->get_sanitized_values( $_POST ); // phpcs:ignore
 		if ( 'off' === $values['console_email_reports'] ) {
 			return;

--- a/includes/modules/analytics/class-url-inspection.php
+++ b/includes/modules/analytics/class-url-inspection.php
@@ -49,7 +49,10 @@ class Url_Inspection {
 		$delay = absint( $delay );
 		if ( $reschedule ) {
 			Schedule::unschedule_action( 'rank_math/analytics/get_inspections_data', [ $page ], 'rank-math' );
-		} elseif ( as_has_scheduled_action( 'rank_math/analytics/get_inspections_data', [ $page ], 'rank-math' ) ) {
+		} elseif (
+			\RankMath\Helper::is_action_scheduler_available()
+			&& as_has_scheduled_action( 'rank_math/analytics/get_inspections_data', [ $page ], 'rank-math' )
+		) {
 			// Already scheduled and reschedule = false.
 			return;
 		}

--- a/includes/modules/analytics/workflows/class-inspections.php
+++ b/includes/modules/analytics/workflows/class-inspections.php
@@ -19,8 +19,6 @@ use RankMath\Analytics\Url_Inspection;
 use RankMath\Google\Console;
 use RankMath\Helpers\Schedule;
 
-use function as_unschedule_all_actions;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -65,6 +63,10 @@ class Inspections {
 	 * Stop processing queue items, clear cronjob and delete all batches.
 	 */
 	public static function kill_jobs() {
+		// Issue #337: bail when AS is missing rather than fatal.
+		if ( ! \RankMath\Helper::is_action_scheduler_available() ) {
+			return;
+		}
 		as_unschedule_all_actions( 'rank_math/analytics/get_inspections_data' );
 	}
 
@@ -112,6 +114,11 @@ class Inspections {
 	 * Create jobs to fetch data.
 	 */
 	public function create_data_jobs() {
+		// Issue #337: bail when AS is missing rather than fatal.
+		if ( ! \RankMath\Helper::is_action_scheduler_available() ) {
+			return;
+		}
+
 		// If there are jobs left from the previous queue, don't create new jobs.
 		if ( as_has_scheduled_action( 'rank_math/analytics/get_inspections_data' ) ) {
 			return;

--- a/rank-math.php
+++ b/rank-math.php
@@ -9,7 +9,7 @@
  *
  * @wordpress-plugin
  * Plugin Name:       Rank Math SEO
- * Version:           1.0.272
+ * Version:           1.0.273
  * Plugin URI:        https://rankmath.com/
  * Description:       Rank Math SEO is the Best WordPress SEO plugin with the features of many SEO and AI SEO tools in a single package to help multiply your SEO traffic.
  * Author:            Rank Math SEO
@@ -34,7 +34,7 @@ final class RankMath {
 	 *
 	 * @var string
 	 */
-	public $version = '1.0.272';
+	public $version = '1.0.273';
 
 	/**
 	 * Rank Math database version.
@@ -261,6 +261,10 @@ final class RankMath {
 	private function includes() {
 		include __DIR__ . '/vendor/autoload.php';
 
+		// Issue #337: load the vendored Action Scheduler only as a fallback
+		// when no other plugin (WooCommerce, UpdraftPlus, etc.) has provided one.
+		$this->maybe_load_action_scheduler();
+
 		if ( class_exists( 'WP\MCP\Core\McpAdapter' ) && function_exists( 'wp_get_abilities' ) ) {
 			\WP\MCP\Core\McpAdapter::instance();
 		}
@@ -271,6 +275,49 @@ final class RankMath {
 		if ( file_exists( $file ) ) {
 			require_once $file;
 		}
+	}
+
+	/**
+	 * Load the vendored Action Scheduler as a fallback when no other plugin
+	 * (WooCommerce, UpdraftPlus, etc.) supplies one.
+	 *
+	 * The package is no longer autoloaded via `composer.json` `autoload.files`
+	 * because eagerly registering our copy on `plugins_loaded` priority 0/1
+	 * caused a first-loader-wins race against WooCommerce's bundled copy.
+	 * That race made the vendored DBStore the active implementation when
+	 * WooCommerce's BatchProcessingController invoked as_has_scheduled_action
+	 * on the WP shutdown hook, and the vendored store fataled on a null
+	 * $wpdb->dbh. See https://github.com/rankmath/seo-by-rank-math/issues/337
+	 *
+	 * @since 1.0.273
+	 *
+	 * @return void
+	 */
+	public function maybe_load_action_scheduler() {
+		// AS already loaded (via WC, mu-plugin, or a prior include on this request).
+		if ( function_exists( 'action_scheduler_register_3_dot_9_dot_3' )
+			|| class_exists( 'ActionScheduler', false ) ) {
+			return;
+		}
+
+		$as_path = __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
+		if ( ! file_exists( $as_path ) ) {
+			return;
+		}
+
+		// Defer until plugins_loaded so is_plugin_active() is reliable and any
+		// AS-vendoring plugin (WC, UpdraftPlus) has had a chance to register
+		// first on the same hook.
+		if ( ! did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) ) {
+			add_action( 'plugins_loaded', [ $this, 'maybe_load_action_scheduler' ], 20 );
+			return;
+		}
+
+		if ( \RankMath\Helper::is_woocommerce_active() ) {
+			return;
+		}
+
+		require_once $as_path;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -375,6 +375,9 @@ Terms of service: https://developers.facebook.com/terms/
 
 == Changelog ==
 
+= 1.0.273 [June 12, 2026] =
+- Fixed Action Scheduler fatal error that occurred at WP shutdown when WooCommerce was active. Rank Math now defers to WooCommerce's bundled Action Scheduler instead of loading its own copy eagerly, preventing the "mysqli_get_server_info() must be of type mysqli, null given" fatal on sites with stale failed actions in the queue.
+
 = 1.0.272 [June 10, 2026] =
 - Added `rank-math/get-link-report` [MCP Tool](https://rankmath.com/kb/mcp-tools/) to let AI assistants retrieve site-wide link statistics, including internal, external, and broken link counts.
 - Added `rank-math/get-post-seo-meta` [MCP Tool](https://rankmath.com/kb/mcp-tools/) to let AI assistants retrieve a post's SEO title, description, focus keyword, robots meta settings, and SEO score.


### PR DESCRIPTION
## Summary

PHP fatal on every WP shutdown when WooCommerce (HPOS) is active. WooCommerce's `BatchProcessingController::remove_or_retry_failed_processors` calls `as_has_scheduled_action` on shutdown, and the symbol resolves to Rank Math's vendored Action Scheduler 3.9.3 because our `composer.json` autoload `files` loaded it on `plugins_loaded` priority 0/1 ahead of WooCommerce's copy. The vendored DBStore then queries a null `$wpdb->dbh` — `mysqli_get_server_info()` fatal.

Fix stops the eager autoload and loads the vendored copy only as a fallback when no other plugin provides one.

Fixes #337

## Changes

### `composer.json` — remove AS from autoload.files

The file is no longer loaded eagerly via `vendor/autoload.php`. The `woocommerce/action-scheduler` package stays in `require` — the classes inside `vendor/woocommerce/action-scheduler/classes/` are still discoverable by the classmap autoloader for code referencing `ActionScheduler_HybridStore` etc. (used in `database-tools.php`).

### `rank-math.php` — new `maybe_load_action_scheduler()` method

Called from `includes()` right after `vendor/autoload.php`. Two-layer guard:
1. Returns immediately if `class_exists('ActionScheduler', false)` — another plugin already registered.
2. Defers to `plugins_loaded` priority 20 if the check runs too early, giving any AS-vendoring plugin time to register first.
3. Final check: if `Helper::is_woocommerce_active()` is true, we yield.
4. Otherwise `require_once` the vendored file.

### `includes/helpers/class-conditional.php` — `is_action_scheduler_available()`

Checks all 6 AS function symbols the plugin calls. Used at every internal AS call site so a missing AS no-op instead of fatal.

### `includes/helpers/class-schedule.php` — 4 guarded AS calls

Each of the 4 wrapper methods returns the documented false value (0 or null) when AS is unavailable.

### Analytics and admin call sites — guarded

- `class-url-inspection.php:52` — `as_has_scheduled_action` check
- `workflows/class-inspections.php:68,116` — `kill_jobs()` and `create_data_jobs()`
- `class-analytics-common.php:274,297` — email report unscheduling
- `class-admin.php:488-510` — `as_exclude_pastdue_actions()` falls back to default

## Testing

**Test 1: Rank Math + WooCommerce (original failure)**
1. Install both plugins, allow stale actions in the queue
2. Hit any URL
3. Check PHP error log

Result: No `mysqli_get_server_info()` fatal on shutdown.

**Test 2: Rank Math alone**
1. Deactivate WooCommerce
2. Load admin page

Result: Analytics scheduling works normally via the vendored AS 3.9.3.

**Test 3: Static checks**
- `composer phpcs`: no new violations
- `composer phpstan`: helper method passes clean
- `coderabbit review`: 0 findings